### PR TITLE
Documentation update

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,10 @@ docker-devpi
 
 This repository contains a Dockerfile for [devpi pypi server](http://doc.devpi.net/latest/).
 
-You can use this container to speed up the `pip install` parts of your docker builds. This is done by adding an optional cache of your requirement python packages and speed up docker. The outcome is faster development without breaking builds.
+You can use this container to speed up the `pip install` parts of your docker
+builds. This is done by adding an optional cache of your requirement python
+packages and speed up docker. The outcome is faster development without
+breaking builds.
 
 # Getting started
 
@@ -24,13 +27,19 @@ docker run -d --name devpi \
     muccg/docker-devpi
 ```
 
-*Alternatively, you can use the sample [docker-compose.yml](docker-compose.yml) file to start the container using [Docker Compose](https://docs.docker.com/compose/)*
+*Alternatively, you can use the sample [docker-compose.yml](docker-compose.yml)
+file to start the container using [Docker
+Compose](https://docs.docker.com/compose/)*
 
-Please set DEVPI_PASSWORD to a secret otherwise an attacker can *execute arbitrary code*.
+Please set ``DEVPI_PASSWORD`` to a secret otherwise an attacker can *execute
+arbitrary code*.
 
 ## Client side usage
 
-To use this devpi cache to speed up your dockerfile builds, add use the code below in your dockerfiles. This will add the devpi container an optional cache for pip. The docker containers will try using port 3141 on the docker host first and fall back on the normal pypi servers without breaking the build.
+To use this devpi cache to speed up your dockerfile builds, add the code below
+in your dockerfiles. This will add the devpi container an optional cache for
+pip. The docker containers will try using port 3141 on the docker host first
+and fall back on the normal pypi servers without breaking the build.
 
 ```Dockerfile
 # Install netcat for ip route
@@ -50,7 +59,9 @@ RUN export HOST_IP=$(ip route| awk '/^default/ {print $3}') \
 
 ## Uploading python packages files
 
-You need to upload your python requirement to get any benefit from the devpi container. You can upload them using the bash code below a similar build environment.
+You need to upload your python requirement to get any benefit from the devpi
+container. You can upload them using the bash code below a similar build
+environment.
 
 ```bash
 pip wheel --download=packages --wheel-dir=wheelhouse -r requirements.txt
@@ -67,10 +78,14 @@ fi
 
 # Persistence
 
-For devpi to preserve its state across container shutdown and startup you should mount a volume at `/data`. The quickstart command already includes this.
+For devpi to preserve its state across container shutdown and startup you
+should mount a volume at `/data`. The quickstart command already includes this.
 
 # Security
 
-Devpi creates a user named root by default, its password should be set with DEVPI_PASSWORD environment variable. Please set it, otherwise attackers can *execute arbitrary code* in your application by uploading modified packages.
+Devpi creates a user named root by default, its password should be set with
+``DEVPI_PASSWORD`` environment variable. Please set it, otherwise attackers can
+*execute arbitrary code* in your application by uploading modified packages.
 
-For additional security the argument `--restrict-modify root` has been added so only the root may create users and indexes.
+For additional security the argument `--restrict-modify root` has been added so
+only the root may create users and indexes.


### PR DESCRIPTION
Cannot use `docker pull muccg/docker-devpi` to pull docker image.

Here's logs:
Using default tag: latest
Pulling repository docker.io/muccg/docker-devpi
Error: image muccg/docker-devpi not found
